### PR TITLE
Simplify signal handling code path

### DIFF
--- a/src/macros.inc
+++ b/src/macros.inc
@@ -425,20 +425,14 @@ parse_request:
   jge        .400 ; invalid url
 
   ; %xx blocks to ascii
-  mov        bx, word [r10 + rcx - 1] ; keep in mind it's still in LE
-  or         rbx, 0010000000100000b
-  bt         rbx, 6+8
-  ; setc       al
-  ; shl        rax, 8
-  setc       ah
-  bt         rbx, 6
-  setc       al
-  mov        rdx, 39
-  mul        rdx ; rax * 39 -> rdx:rax
-  sub        rbx, rax
-  and        rbx, 0000111100001111b
-  shl        bh, 4
-  rol        bx, 4 ; fix the order
+  mov        bl, byte [r10 + rcx - 2]
+  mov        bh, byte [r10 + rcx - 1]
+  sub        bl, '0'
+  sub        bh, '0'
+  and        bl, 0xF
+  and        bh, 0xF
+  shl        bl, 4
+  or         bl, bh
   jmp        .loop
 
 .no_hex:

--- a/src/main.asm
+++ b/src/main.asm
@@ -324,11 +324,6 @@ start:
   Syscall SYS_accept4, r14, NULL, NULL, SOCK_NONBLOCK
   cmp     rax, 0
   jge     @f
-
-  ; this just means another thread already handled this
-  cmp     rax, -EAGAIN ; EWOULDBLOCK also aliases to EAGAIN on linux
-  je      .switch_end
-
   error   20, "failed to accept connection"
 @@:
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -526,8 +526,6 @@ start:
 ; if we poll a signal, we exit the thread without even consuming it
 ; so other processes can do the same aswell
 .signal_event:
-  pop     r14
-  ; mov     [is_running], 0
   jmp     .worker_cleanup
   
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -349,7 +349,6 @@ start:
   ; get a new object and fill it out
   call    acquire_client_obj
 
-  mov     rdi, r15
   xor     rax, rax
   mov     rcx, 512 ; 4096/8
   rep     stosq ; we can probably do better than swar


### PR DESCRIPTION
Remove unnecessary register pop operation
Remove commented code
Direct jump to cleanup routine
Reduces binary size by ~5 bytes